### PR TITLE
Add link to API version of recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Import `osm2pgsql_tuner` and create an instance of the `recommendation` class.
 ```python
 import osm2pgsql_tuner
 rec = osm2pgsql_tuner.recommendation(system_ram_gb=8,
-									 osm_pbf_gb=0.5,
-									 pgosm_layer_set='run')
+                                     osm_pbf_gb=0.5,
+                                     pgosm_layer_set='run')
 osm2pgsql_command = rec.get_osm2pgsql_command(out_format='api',
-											  pbf_filename='example_file')
+                                              pbf_filename='example_file')
 print(osm2pgsql_command)
 ```
 
@@ -122,7 +122,9 @@ coverage report -m osm2pgsql_tuner/*.py webapp/*.py
 Run pylint.
 
 ```bash
-pylint --rcfile=./.pylintrc -f parseable ./webapp/*.py
+pylint --rcfile=./.pylintrc -f parseable \
+    ./webapp/*.py \
+    ./osm2pgsql_tuner/*.py
 ```
 
 

--- a/tests/routes_test.py
+++ b/tests/routes_test.py
@@ -1,0 +1,30 @@
+import unittest
+from webapp import app, routes
+
+# Load configurables for tests
+from .test_params import *
+
+
+class RoutesTests(unittest.TestCase):
+
+    def setUp(self):
+        """ setUp is triggered before executing every test by the framework """
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.app = app.test_client()
+
+
+    def test_route_home_includes_expected_test(self):
+        page_data = self.app.get('/')
+        expected = 'Find the right osm2pgsql command'
+        msg = 'The expected text was not found:  {}.'.format(expected)
+        self.assertTrue(expected in str(page_data.data), msg)
+
+    def test_route_build_url_params_returns_str(self):
+        actual = routes.build_url_params(system_ram_gb=SYSTEM_RAM_GB_SMALL,
+                                         osm_pbf_gb=OSM_PBF_GB_US,
+                                         append=False,
+                                         pbf_filename='not-important')
+        expected = 'system_ram_gb=1&osm_pbf_gb=10.4&append=False&pbf_filename=not-important&pgosm_layer_set=run'
+        self.assertEqual(expected, actual)
+

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,13 @@
+"""Common values used for testing.
+"""
+SYSTEM_RAM_GB_MAIN = 64
+SYSTEM_RAM_GB_SMALL = 1
+OSM_PBF_GB_US = 10.4
+
+OSM_PBF_GB_CO = 0.2
+
+# Scaled below the 2GB threshold...
+OSM_PBF_GB_USWEST = 1.99
+
+# Should always use flat file, even w/out SSD
+OSM_PBF_GB_ALWAYS_FLAT_FILE = 30.1

--- a/tests/tuner_test.py
+++ b/tests/tuner_test.py
@@ -2,14 +2,9 @@
 import unittest
 from osm2pgsql_tuner import tuner
 
+# Load configurables for tests
+from .test_params import *
 
-SYSTEM_RAM_GB_MAIN = 64
-SYSTEM_RAM_GB_SMALL = 1
-OSM_PBF_GB_US = 10.4
-
-OSM_PBF_GB_CO = 0.2
-OSM_PBF_GB_USWEST = 1.99 # Scaled below the 2GB threshold...
-OSM_PBF_GB_ALWAYS_FLAT_FILE = 30.1 # Should always use flat file, even w/out SSD
 
 
 class Osm2pgsqlTests(unittest.TestCase):

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -1,3 +1,5 @@
+"""Configuration for osm2pgsql-tuner webapp.
+"""
 import os
 
 

--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -1,6 +1,5 @@
 """Provides Flask Forms related functionality."""
-from wtforms import TextAreaField, DecimalField, SelectField, BooleanField
-from wtforms.validators import DataRequired, NumberRange
+from wtforms import SelectField, BooleanField
 from flask_wtf import FlaskForm
 from webapp import config
 
@@ -13,7 +12,7 @@ def _get_pbf_gb_choices():
     pbf_gb_choices : list
         list of tuples
     """
-    pbf_gb_choices = list()
+    pbf_gb_choices = []
     for key, value in config.PBF_GB_SIZES.items():
         choice = (key,
                   f"{key} ({value['size_gb']} GB)")
@@ -23,6 +22,7 @@ def _get_pbf_gb_choices():
 
 
 class Osm2pgsqlTunerInput(FlaskForm):
+    """Input form for osm2pgsql-tuner webapp"""
     system_ram_gb = SelectField('System RAM (GB)',
                                 default=64,
                                 choices=[4, 8, 16, 32, 64, 128, 256])

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -61,6 +61,7 @@ def _get_api_params():
 
     return api_params
 
+
 def _get_recommendation(out_format):
     api_params = _get_api_params()
 
@@ -82,6 +83,7 @@ def _get_recommendation(out_format):
                 'osm2pgsql_append': rec.append}
 
     return rec_data
+
 
 @app.route('/recommendation')
 def view_recommendation():

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -21,11 +21,10 @@ def view_root_path():
         osm_pbf_gb = osm_pbf_details['size_gb']
         pbf_filename = osm_pbf_details['filename']
         append = form.append.data
-        url_params = f'system_ram_gb={system_ram_gb}'
-        url_params += f'&osm_pbf_gb={osm_pbf_gb}'
-        url_params += f'&append={append}'
-        url_params += f'&pbf_filename={pbf_filename}'
-        url_params += f'&pgosm_layer_set=run-all'
+        url_params = build_url_params(system_ram_gb,
+                                      osm_pbf_gb,
+                                      append,
+                                      pbf_filename)
         return redirect(f'/recommendation?{url_params}')
 
     return render_template('index.html', form=form)
@@ -88,7 +87,14 @@ def _get_recommendation(out_format):
 def view_recommendation():
     rec_data = _get_recommendation(out_format='html')
     params = request.args
-    return render_template('recommendation.html', rec_data=rec_data)
+    url_params = build_url_params(params['system_ram_gb'],
+                                  params['osm_pbf_gb'],
+                                  params['append'],
+                                  params['pbf_filename'])
+    api_url = f'{api_uri}?{url_params}'
+    return render_template('recommendation.html',
+                           rec_data=rec_data,
+                           api_url=api_url)
 
 
 @app.route(api_uri)
@@ -100,4 +106,26 @@ def view_recommendation_api():
 @app.route('/about')
 def view_about():
     return render_template('about.html')
+
+
+def build_url_params(system_ram_gb, osm_pbf_gb, append, pbf_filename):
+    """Creates the URL parameter string from individual components.
+
+    Parameters
+    ------------------------
+    system_ram_gb : float
+    osm_pbf_gb : float
+    append : bool
+    pbf_filename : str
+
+    Returns
+    ------------------------
+    url_params : str
+    """
+    url_params = f'system_ram_gb={system_ram_gb}'
+    url_params += f'&osm_pbf_gb={osm_pbf_gb}'
+    url_params += f'&append={append}'
+    url_params += f'&pbf_filename={pbf_filename}'
+    url_params += f'&pgosm_layer_set=run'
+    return url_params
 

--- a/webapp/templates/recommendation.html
+++ b/webapp/templates/recommendation.html
@@ -66,6 +66,15 @@
         </div>
     </div>
 
+    <div class="row text-center">
+        <div class="col-md-8 p-3">
+            <a href="{{ api_url }}">
+                <button type="button" class="btn btn-info">
+                API version
+                </button>
+            </a>
+        </div>
+    </div>
 </div>
 
 {% endblock main_content %}


### PR DESCRIPTION
# Main change

Adds easy button to get API version from a recommendation.

Closes #12.

## :warning: Breaking Change :warning: 

This PR includes a slight change in the returned command.  `--style=./run-all.lua` changes to `--style=./run.lua`.

----

## Also

* Pylint cleanup
* A couple more basic unit tests
