### PR TITLE
Allow tuner backend to work with file path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ import osm2pgsql_tuner
 rec = osm2pgsql_tuner.recommendation(system_ram_gb=8,
                                      osm_pbf_gb=0.5,
                                      pgosm_layer_set='run')
+pbf_path = '~/pgosm-data/example_file.osm.pbf'
 osm2pgsql_command = rec.get_osm2pgsql_command(out_format='api',
-                                              pbf_filename='example_file')
+                                              pbf_path=pbf_path)
 print(osm2pgsql_command)
 ```
 

--- a/osm2pgsql_tuner/tuner.py
+++ b/osm2pgsql_tuner/tuner.py
@@ -252,12 +252,3 @@ class recommendation(object):
 
         self.decisions.append(decision)
         return cache
-
-
-    def _get_postgres_conf_suggestion(self):
-        shared_buffers_gb = 1
-        work_mem_mb = 50
-
-        postgres_conf = {'shared_buffers': f'{shared_buffers_gb} GB',
-                         'work_mem': f'{work_mem_mb} MB'}
-        return postgres_conf

--- a/osm2pgsql_tuner/tuner.py
+++ b/osm2pgsql_tuner/tuner.py
@@ -1,6 +1,6 @@
 """Contains osm2pgsql class to help provide osm2pgsql tuning advice.
 
-Requires osm2pgsql v1.5.0 or newer
+Recommendations require osm2pgsql v1.5.0 or newer
 """
 
 
@@ -186,14 +186,14 @@ class recommendation(object):
         return in_ram_possible
 
 
-    def get_osm2pgsql_command(self, out_format, pbf_filename):
+    def get_osm2pgsql_command(self, out_format, pbf_path):
         """Builds the recommended osm2pgsql command.
 
         Parameters
         -----------------------
         out_format : str
             Either `api` or `html`.
-        pbf_filename : str
+        pbf_path : str
 
         Returns
         -----------------------
@@ -213,7 +213,7 @@ class recommendation(object):
                 cmd += ' --flat-nodes=/tmp/nodes \ \n'
 
         cmd += f' --output=flex --style=./{self.pgosm_layer_set}.lua \ \n'
-        cmd += f' ~/pgosm-data/{pbf_filename}.osm.pbf'
+        cmd += f' {pbf_path}'
 
         if out_format == 'api':
             cmd = cmd.replace('\ \n', '')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='osm2pgsql_tuner',
-      version='0.0.4',
+      version='0.0.5.rc1',
       description='osm2pgsql tuner',
       url='https://github.com/rustprooflabs/osm2pgsql-tuner',
       author='RustProof Labs',

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -78,8 +78,11 @@ def _get_recommendation(out_format):
 
             return abort(400, err_msg)
 
+    pbf_filename = api_params['pbf_filename']
+    pbf_path = f'~/pgosm-data/{pbf_filename}.osm.pbf'
     cmd = rec.get_osm2pgsql_command(out_format=out_format,
-                                    pbf_filename=api_params['pbf_filename'])
+                                    pbf_path=pbf_path)
+
     rec_data = {'cmd': cmd, 'decisions': rec.decisions,
                 'osm2pgsql_run_in_ram': rec.osm2pgsql_run_in_ram,
                 'osm2pgsql_noslim_cache': rec.osm2pgsql_noslim_cache,


### PR DESCRIPTION
Closes #21.

Update tuner to accept full path instead of making path and file extension opinions.  Moves the hard coded path to `routes.py`. Right now I'm ok with not exposing this flexibility through the webapp/api, but only the python package.
