### PR TITLE
Improve append mode - support 1st import vs subsequent imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,13 @@ pylint --rcfile=./.pylintrc -f parseable \
 
 This project is used by [PgOSM Flex](https://github.com/rustprooflabs/pgosm-flex)
 to automate commands in the [PgOSM Flex Docker image](https://hub.docker.com/r/rustprooflabs/pgosm-flex).
+
+
+## Development install
+
+
+```
+pip install -e .
+```
+
+

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='osm2pgsql_tuner',
-      version='0.0.6-dev',
+      version='0.0.6-rc1',
       description='The osm2pgsql-tuner project recommends an osm2pgsql command based on available system resources and the size of the input PBF file.',
       url='https://github.com/rustprooflabs/osm2pgsql-tuner',
       author='RustProof Labs',

--- a/tests/tuner_test.py
+++ b/tests/tuner_test.py
@@ -84,11 +84,17 @@ class Osm2pgsqlTests(unittest.TestCase):
         expected = False
         self.assertEqual(expected, result)
 
+    def test_osm2pgsql_recommendation_osm2pgsql_append_with_additional_param_raises_ValueError(self):
+        with self.assertRaises(ValueError):
+            tuner.recommendation(system_ram_gb=OSM_PBF_GB_US,
+                                 osm_pbf_gb=OSM_PBF_GB_US,
+                                 append=True)
+
     def test_osm2pgsql_recommendation_osm2pgsql_drop_value_false_with_append(self):
         # NOTE: Setting system ram == PBF size to ensure slim is used
         rec = tuner.recommendation(system_ram_gb=OSM_PBF_GB_US,
                                        osm_pbf_gb=OSM_PBF_GB_US,
-                                       append=True)
+                                       append=True, append_first_run=True)
         result = rec.osm2pgsql_drop
         expected = False
         self.assertEqual(expected, result)
@@ -168,14 +174,14 @@ class Osm2pgsqlTests(unittest.TestCase):
         rec = tuner.recommendation(SYSTEM_RAM_GB_SMALL, OSM_PBF_GB_US)
         pbf_path = 'blahblah'
         result = rec.get_osm2pgsql_command(out_format='api', pbf_path=pbf_path)
-        expected = f'osm2pgsql -d $PGOSM_CONN  --cache=0  --slim  --drop  --flat-nodes=/tmp/nodes  --output=flex --style=./run.lua  {pbf_path}'
+        expected = f'osm2pgsql -d $PGOSM_CONN  --cache=0  --slim  --drop  --flat-nodes=/tmp/nodes  --create  --output=flex --style=./run.lua  {pbf_path}'
         self.assertEqual(expected, result)
 
     def test_osm2pgsql_recommendation_osm2pgsql_get_osm2pgsql_command_value_is_in_ram(self):
         rec = tuner.recommendation(SYSTEM_RAM_GB_MAIN, OSM_PBF_GB_US)
         pbf_path = 'blahblah'
         result = rec.get_osm2pgsql_command(out_format='api', pbf_path=pbf_path)
-        expected = f'osm2pgsql -d $PGOSM_CONN  --output=flex --style=./run.lua  {pbf_path}'
+        expected = f'osm2pgsql -d $PGOSM_CONN  --create  --output=flex --style=./run.lua  {pbf_path}'
         self.assertEqual(expected, result)
 
     def test_osm2pgsql_recommendation_osm2pgsql_get_osm2pgsql_command_error_invalid_type(self):
@@ -183,3 +189,22 @@ class Osm2pgsqlTests(unittest.TestCase):
         pbf_path = 'blahblah'
         self.assertRaises(ValueError, rec.get_osm2pgsql_command, 'invalid', pbf_path)
 
+    def test_osm2pgsql_recommendation_osm2pgsql_command_append_first_run_correct_cmd(self):
+        append = True
+        append_first_run = True
+        rec = tuner.recommendation(SYSTEM_RAM_GB_MAIN, OSM_PBF_GB_US,
+                                   append=append, append_first_run=append_first_run)
+        pbf_path = 'blahblah'
+        result = rec.get_osm2pgsql_command(out_format='api', pbf_path=pbf_path)
+        expected = f'osm2pgsql -d $PGOSM_CONN  --cache=0  --slim  --flat-nodes=/tmp/nodes  --create  --output=flex --style=./run.lua  {pbf_path}'
+        self.assertEqual(expected, result)
+
+    def test_osm2pgsql_recommendation_osm2pgsql_command_append_subsequent_run_correct_cmd(self):
+        append = True
+        append_first_run = False
+        rec = tuner.recommendation(SYSTEM_RAM_GB_MAIN, OSM_PBF_GB_US,
+                                   append=append, append_first_run=append_first_run)
+        pbf_path = 'blahblah'
+        result = rec.get_osm2pgsql_command(out_format='api', pbf_path=pbf_path)
+        expected = f'osm2pgsql -d $PGOSM_CONN  --cache=0  --slim  --flat-nodes=/tmp/nodes  --append  --output=flex --style=./run.lua  {pbf_path}'
+        self.assertEqual(expected, result)

--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -30,6 +30,7 @@ class Osm2pgsqlTunerInput(FlaskForm):
     osm_pbf = SelectField('OSM PBF size (GB)',
                           default='North America',
                           choices=pbf_gb_choices)
-    append = BooleanField('Use Append?', default=False)
+    append = SelectField('Use Append?', default='No',
+                         choices=['No', 'Yes, 1st import', 'Yes, 2nd or later'])
     ssd = SelectField('Using SSD?', default='Yes, SSD',
                        choices=['Yes, SSD'])

--- a/webapp/templates/_footer.html
+++ b/webapp/templates/_footer.html
@@ -1,5 +1,6 @@
 <div>
-    <a href="/about">About this tool</a>
+    osm2pgsql-tuner version: {{ g.tuner_version }}
+    -- <a href="/about">About this tool</a>
     <br />
     © RustProof Labs
     <br />

--- a/webapp/templates/about.html
+++ b/webapp/templates/about.html
@@ -6,9 +6,14 @@
       About
     </h1>
 
+    <h2 class="row text-center p-2">
+        osm2pgsql-tuner version: {{ g.tuner_version }}
+    </h2>
+
+
     <div class="row text-center p-2">
 
-        <p class="col-md-8 alert alert-success">
+        <p class="col-md-8">
             This project is open source and available on
             <a href="https://github.com/rustprooflabs/osm2pgsql-tuner">GitHub</a>.
             Submit bugs, questions, or ideas for improvement
@@ -16,8 +21,10 @@
             here
             </a>.
         </p>
-
     </div>
+
+
+
 
     <div class="row text-center p-2">
 


### PR DESCRIPTION
Addresses #24.

Adjust append mode for initial import v subsequent imports. 

The quickly updated Web / API interface uses unfortunate options (3 text values in the "append" form input, and a name that does not accurately reflect underlying tuner signature.